### PR TITLE
Proposal for issue #17: Playercount in activity

### DIFF
--- a/src/Utility/Activity.js
+++ b/src/Utility/Activity.js
@@ -1,0 +1,57 @@
+const BotModule = require('../BotModule');
+
+const cacheTTL = 10 * 1000; // 10 seconds in milliseconds
+const updateInterval = 60 * 1000 // 1 minute in milliseconds
+
+module.exports = BotModule.extend({
+    https: null,
+    cache: null,
+    cacheKey: 'serverlist',
+    dependencies: {
+        'https': 'https',
+        'Cache': 'cache'
+    },
+    initialize: function (dependencyGraph) {
+        this._super(dependencyGraph);
+        setInterval(() => {
+            this.fetchServerlist(serverList => {
+                if (serverList === false) {
+                    this.discordClient.user.setActivity('on Shotbow');
+                    return;
+                }
+                this.discordClient.user.setActivity(`on Shotbow with ${serverList.all} others`);
+            });
+        }, updateInterval);
+    },
+    fetchServerlist: function (callback) {
+        let cachedData = this.cache.get(this.cacheKey);
+        if (cachedData) {
+            callback(cachedData);
+            return;
+        }
+        try {
+            this.https.get('https://shotbow.net/serverList.json', res => {
+                let responseData = '';
+                res.setEncoding('utf8');
+                res.on('data', data => {
+                    responseData += data;
+                });
+                res.on('end', () => {
+                    let serverList;
+                    try {
+                        serverList = JSON.parse(responseData);
+                        if (serverList !== false) {
+                            this.cache.set(this.cacheKey, serverList, cacheTTL);
+                        }
+                        callback(serverList);
+                    } catch (e) {
+                        callback(false);
+                    }
+                });
+            });
+        } catch (e) {
+            console.error(e);
+            callback(false);
+        }
+    }
+});


### PR DESCRIPTION
I have created another utility for this feature. Right now, this proposal is a rather similar implementation of the Playercount.js file, but a lot stripped back. When no playercount could be retrieved, the old message of "playing on Shotbow" is simply displayed. When a playercount is retrieved successfully, "playing on Shotbow with x others" is displayed.

Right now this proposal makes use of setInterval() as the requests are made every minute. This is plenty of time for setInterval() to work as expected. If shorter intervals are needed, a recursive setTimeout() might work as well, though it might be a bit iffy to fix the "this"-problem that will then pop up as the reference to the BotModule via "this" breaks after the first setTimeout(), as the timeout will become "this".

Once the config PR has passed through, some duplicate constants here and on Playercount.js can be moved to configs (cache name, cache TTL, etc.).