### PR TITLE
Feature/pingspam

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -92,5 +92,10 @@ module.exports = {
         'Minecraft Forum': 'http://minecraftforum.net/servers/160-shotbow',
         'MinecraftServers.org': 'http://minecraftservers.org/server/267066'
     },
-    messageRemoveDelay: 60000
+    messageRemoveDelay: 60000,
+    pingspam: {
+        threshold: 5,
+        timespan: 30000,
+        cooldown: 5000
+    }
 }

--- a/config/default.js
+++ b/config/default.js
@@ -96,6 +96,6 @@ module.exports = {
     pingspam: {
         threshold: 5,
         timespan: 30000,
-        cooldown: 5000
+        cooldown: 60000
     }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -61,5 +61,13 @@
 	"Unmuted @{username}#{discriminator}": "Unmuted @{username}#{discriminator}",
 	"Please use the correct format: `{command} <@User#9999> <Reason>`.": "Please use the correct format: `{command} <@User#9999> <Reason>`.",
 	"In addition, I was unable to DM the user about their mute. It is likely that they have DMs disabled.": "In addition, I was unable to DM the user about their mute. It is likely that they have DMs disabled.",
-	"Deleted message authored by @{username}#{discriminator}": "Deleted message authored by @{username}#{discriminator}"
+	"Deleted message authored by @{username}#{discriminator}": "Deleted message authored by @{username}#{discriminator}",
+	"You are on a temporary cooldown on the Shotbow Discord": "You are on a temporary cooldown on the Shotbow Discord",
+	"Cooldown Reason": "Cooldown Reason",
+	"Excessive pinging of other members.": "Excessive pinging of other members.",
+	"Expiration": "Expiration",
+	"You can talk again in {cooldown} seconds.": "You can talk again in {cooldown} seconds.",
+	"@{username}#{discriminator} was put on cooldown after excessive pinging": "@{username}#{discriminator} was put on cooldown after excessive pinging",
+	"You can talk again on the Shotbow Discord": "You can talk again on the Shotbow Discord",
+	"Do not use pings excessively. If you are caught again, you can risk a permanent mute.": "Do not use pings excessively. If you are caught again, you can risk a permanent mute."
 }

--- a/src/Utility/PingSpam.js
+++ b/src/Utility/PingSpam.js
@@ -1,0 +1,133 @@
+const BotModule = require('../BotModule');
+
+module.exports = BotModule.extend({
+    config: null,
+    dependencies: {
+        'config': 'config',
+        'i18n': 'i18n'
+    },
+    counts: {},
+    cooldown: [],
+    initialize: function (dependencyGraph) {
+        this._super(dependencyGraph);
+        this.discordClient.on('message', (message) => {
+            if (message.guild == null) return; // People can DM the bot, in which case guild == null
+
+            /* If the member is already on cooldown, delete their message */
+            const id = message.member.user.id;
+            if (this.cooldown.indexOf(id) > -1) {
+                message.delete();
+                return;
+            }
+
+            /* If there are no pings in this message, ignore it */
+            const amountOfPings = message.mentions.users.size
+            if (amountOfPings === 0) {
+                return;
+            }
+            this.counts[id] ? this.counts[id] += amountOfPings : this.counts[id] = amountOfPings;
+
+            /* If the user has exceeded the ping threshold, put them on cooldown */
+            if (this.counts[id] >= this.config.pingspam.threshold) {
+                this.cooldown.push(id);
+                this.notifyVictimMuted(message, this.config, this.i18n, this.discordClient);
+                this.notifyModerationChannel(message, this.config, this.i18n, this.discordClient);
+
+                setTimeout(() => {
+                    this.cooldown.splice(this.cooldown.indexOf(id), 1);
+                    this.notifyVictimUnmuted(message, this.config, this.i18n, this.discordClient);
+                }, this.config.pingspam.cooldown);
+            }
+
+            /* Set a timeout to remove the amount of pings again after the threshold expired */
+            setTimeout(() => {
+                let previousAmountOfPings = this.counts[message.member.user.id];
+                if (previousAmountOfPings) {
+                    previousAmountOfPings - amountOfPings <= 0
+                        ? delete this.counts[message.member.user.id]
+                        : this.counts[message.member.user.id] -= amountOfPings;
+                }
+            }, this.config.pingspam.timespan);
+        });
+    },
+    notifyVictimMuted: function (message, config, i18n, discordClient) {
+        message.member.user.send({
+            embed: {
+                color: 0xff0000,
+                author: {
+                    name: discordClient.user.username,
+                    icon_url: discordClient.user.avatarURL
+                },
+                title: i18n.__mf("You are on a temporary cooldown on the Shotbow Discord"),
+                fields: [
+                    {
+                        name: i18n.__mf("Cooldown Reason"),
+                        value: i18n.__mf("Excessive pinging of other members.")
+                    },
+                    {
+                        name: i18n.__mf("Expiration"),
+                        value: i18n.__mf("You can talk again in {cooldown} seconds.", {cooldown: config.pingspam.cooldown / 1000})
+                    }
+                ],
+                timestamp: new Date(),
+                footer: {
+                    icon_url: discordClient.user.avatarURL,
+                    text: "Shotbow Chat Bot"
+                }
+            }
+        })
+            .catch(() => {
+                message.guild.channels.find('id', config.moderationLogsRoom).send(i18n.__mf('In addition, I was unable to DM the user about their mute. It is likely that they have DMs disabled.'))
+                    .catch(() => {
+                        console.log("Not enough permissions to send a message to the moderation room.");
+                    });
+            });
+    },
+    notifyVictimUnmuted: function (message, config, i18n, discordClient) {
+        message.member.user.send({
+            embed: {
+                color: 0x66ff00,
+                author: {
+                    name: discordClient.user.username,
+                    icon_url: discordClient.user.avatarURL
+                },
+                title: i18n.__mf("You can talk again on the Shotbow Discord"),
+                fields: [
+                    {
+                        name: i18n.__mf("Friendly Reminder"),
+                        value: i18n.__mf("Do not use pings excessively. If you are caught again, you can risk a permanent mute.")
+                    }
+                ],
+                timestamp: new Date(),
+                footer: {
+                    icon_url: discordClient.user.avatarURL,
+                    text: "Shotbow Chat Bot"
+                }
+            }
+        })
+            .catch(() => {
+                message.guild.channels.find('id', this.config.moderationLogsRoom).send(i18n.__mf('In addition, I was unable to DM the user about their unmute. It is likely that they have DMs disabled.'))
+                    .catch(() => {
+                        console.log("Not enough permissions to send a message to the moderation room.");
+                    });
+            });
+    },
+    notifyModerationChannel: function (message, config, i18n, discordClient) {
+        message.guild.channels.find('id', config.moderationLogsRoom).send({
+            embed: {
+                color: 0xff0000,
+                title: i18n.__mf("@{username}#{discriminator} was put on cooldown after excessive pinging", {
+                    username: message.author.username,
+                    discriminator: message.author.discriminator
+                }),
+                timestamp: new Date(),
+                description: 'Channel: ' + message.channel,
+                footer: {
+                    icon_url: discordClient.user.avatarURL,
+                    text: "Shotbow Chat Bot"
+                }
+            }
+        })
+            .catch(() => console.log("Not enough permissions to send a message to the moderation room."));
+    }
+});


### PR DESCRIPTION
I've added a functionality that automatically mutes members for a certain amount of time when they start spamming pings. This is not just limited to pinging staff members, but all members in general.

The mute is temporary and only stored in memory, meaning it is not possible for someone to get permanently muted by this automated process.

There are 3 new configuration options:
- threshold: the amount of unique pings in a single message  or spread over multiple messages to trigger the mute.
- timespan: the timespan that a certain amount of pings is valid for. For example, if I were to ping someone, it will record this single ping for the timespan amount of time before it is removed again.
- cooldown: the length of the mute.

The bot will notify both the member as well as the moderation channel.

Part of issue https://github.com/Shotbow/ChatBot/issues/62