### PR TITLE
Various fixes for the support command

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -99,6 +99,7 @@ module.exports = {
     },
     support: {
         category: '740654285154549901',
+        automaticDeletion: 3600000,
         types: {
             'minez': {
                 description: "Support for MineZ: Stuck in a block; Broken dungeons; Death due to cheaters, bugs, and broken dungeons.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -94,5 +94,6 @@
 	"Closing this support room...": "Closing this support room...",
 	"Support type": "Support type",
 	"Participants": "Participants",
-	"{user} closed support room `{room}`": "{user} closed support room `{room}`"
+	"{user} closed support room `{room}`": "{user} closed support room `{room}`",
+	"*none*": "*none*"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -95,5 +95,6 @@
 	"Support type": "Support type",
 	"Participants": "Participants",
 	"{user} closed support room `{room}`": "{user} closed support room `{room}`",
-	"*none*": "*none*"
+	"*none*": "*none*",
+	"Thank you for your message! If you have more information, you can continue sending messages in this channel. A staff member will get to you soon. ({roles})": "Thank you for your message! If you have more information, you can continue sending messages in this channel. A staff member will get to you soon. ({roles})"
 }

--- a/src/Command/Support.js
+++ b/src/Command/Support.js
@@ -272,7 +272,7 @@ module.exports = Command.extend({
         if (clonedTokens.length === 0) {
             return {
                 command,
-                supportType,
+                supportType: supportType.toLowerCase(),
                 ign: null
             }
         }

--- a/src/Command/Support.js
+++ b/src/Command/Support.js
@@ -71,6 +71,18 @@ module.exports = Command.extend({
             }
         }
 
+        /* Get the support type */
+        const typeKey = commandParameters.supportType;
+        const type = this.config.support.types[typeKey];
+        if (!type) {
+            const types = Object.keys(this.config.support.types).map(type => this.i18n.__mf(messages.type, {
+                type,
+                description: this.config.support.types[type].description
+            }));
+            const helpText = this.i18n.__mf(messages.help, {types});
+            return message.channel.send(this.i18n.__mf(messages.unknownType, {type: typeKey, help: helpText}));
+        }
+
         /* Handle the case of no username provided */
         if (!commandParameters.ign) {
             if (commandParameters.command === 'support') {
@@ -83,18 +95,6 @@ module.exports = Command.extend({
                     command: commandParameters.command
                 }));
             }
-        }
-
-        /* Get the support type */
-        const typeKey = commandParameters.supportType;
-        const type = this.config.support.types[typeKey];
-        if (!type) {
-            const types = Object.keys(this.config.support.types).map(type => this.i18n.__mf(messages.type, {
-                type,
-                description: this.config.support.types[type].description
-            }));
-            const helpText = this.i18n.__mf(messages.help, {types});
-            return message.channel.send(this.i18n.__mf(messages.unknownType, {type: typeKey, help: helpText}));
         }
 
         /* Create the channel and add the correct people to it */

--- a/src/Command/Support.js
+++ b/src/Command/Support.js
@@ -146,7 +146,8 @@ module.exports = Command.extend({
     processDeletion: async function (message) {
         await message.channel.send(this.i18n.__mf(messages.roomClosing));
         const logFile = await getChannelLog(message.channel);
-        await message.channel.delete("Support room closed").catch(() => {});
+        await message.channel.delete("Support room closed").catch(() => {
+        });
 
         /* Notify the moderation channel */
         const guild = message.channel.guild;
@@ -156,6 +157,13 @@ module.exports = Command.extend({
             invalid configuration of log channel`);
             return;
         }
+
+        /* Fetch all the participants and turn them into a displayable string */
+        let participants = (await this.getRoomParticipants(message.channel))
+            .filter(participant => participant.id !== this.discordClient.user.id)
+            .map(participant => participant.displayName)
+            .join(', ');
+
         const embedMessage = await logChannel.send({
             embed: {
                 color: 0x2196f3,
@@ -174,7 +182,7 @@ module.exports = Command.extend({
                     },
                     {
                         name: this.i18n.__mf(messages.roomParticipants),
-                        value: (await this.getRoomParticipants(message.channel)).join(',')
+                        value: participants
                     }
                 ],
                 timestamp: new Date(),
@@ -310,7 +318,8 @@ module.exports = Command.extend({
         for (const permissionOverwrite of permissionOverwrites) {
             await guild.members.fetch(permissionOverwrite.id)
                 .then(participant => participants.push(participant))
-                .catch(() => {});
+                .catch(() => {
+                });
         }
 
         return participants;

--- a/src/Command/Support.js
+++ b/src/Command/Support.js
@@ -9,6 +9,7 @@ const getChannelLog = require('../Helper/ChannelLogger');
 const messages = {
     'help': 'You can use `!support <type> <IGN>` to create a room where you can contact the staff team for support in private, where `<IGN>` is your Minecraft username and `<type>` is one of the following:{types}',
     'type': '\n- `{type}`: {description}',
+    'none': '*none*',
     'unknownType': 'Unknown support type `{type}`.\n\n{help}',
     'roomCreated': 'I\'ve created a support room of type `{type}` and added you to it!',
     'roomConverted': 'I\'ve converted this room\'s support type from `{oldType}` to `{newType}`.',
@@ -159,7 +160,7 @@ module.exports = Command.extend({
         }
 
         /* Fetch all the participants and turn them into a displayable string */
-        let participants = (await this.getRoomParticipants(message.channel))
+        const participants = (await this.getRoomParticipants(message.channel))
             .filter(participant => participant.id !== this.discordClient.user.id)
             .map(participant => participant.displayName)
             .join(', ');
@@ -182,7 +183,7 @@ module.exports = Command.extend({
                     },
                     {
                         name: this.i18n.__mf(messages.roomParticipants),
-                        value: participants
+                        value: participants.length === 0 ? this.i18n.__mf(messages.none) : participants
                     }
                 ],
                 timestamp: new Date(),

--- a/src/Helper/ChannelLogger.js
+++ b/src/Helper/ChannelLogger.js
@@ -41,10 +41,10 @@ const fetchAllMessages = async (channel) => {
 }
 
 const convertMessageToLogMessage = (message) => {
+    const attachmentUrls = message.attachments.map(attachment => attachment.url);
+    const attachmentPart = attachmentUrls.length > 0 ? ` - attachments: ${attachmentUrls.join(', ')}` : "";
     const timestamp = moment(message.createdAt).tz('UTC').toISOString();
-    const logMessage = `${timestamp} - <@${message.author.id}> (${message.author.username}) - ${message.content}`;
-    logMessage.replace(/\\n/g, '\\n');
-    return logMessage;
+    return `${timestamp} - <@${message.author.id}> (${message.author.username}) - ${message.content}${attachmentPart}`;
 }
 
 const getLogFileName = (channel) => {


### PR DESCRIPTION
The following issues were discovered in the support command:
- [x] The list of participants contained Chat Bot as well
- [x] The list of participants showed only the IDs of members, as those members aren't in the log channel so they can't be resolved
- [x] Attachments show up as empty messages in the logs
- [x] Capitalization was an issue when resolving support type
- [x] Wrong order of checking parameters: support type should be checked prior to IGN

Additionally, the following features were still requested:
- [x] Ping the support roles after the first message that is placed by the user.