### PR TITLE
[On Nitro Boost] Replace bad .find with .get

### DIFF
--- a/src/Utility/NitroBoost.js
+++ b/src/Utility/NitroBoost.js
@@ -30,7 +30,7 @@ module.exports = BotModule.extend({
             return;
         }
 
-        newMember.guild.channels.cache.find(this.config.nitro.channel).send(
+        newMember.guild.channels.cache.get(this.config.nitro.channel).send(
             this.i18n.__mf(
                 messages.boost,
                 {


### PR DESCRIPTION
It seems that the bot is no longer crashing when people get Nitro, but it also isn't doing anything.