### PR TITLE
Remove time command after X seconds

### DIFF
--- a/src/Command/Time.js
+++ b/src/Command/Time.js
@@ -5,6 +5,7 @@ module.exports = Command.extend({
     commandAliases: ['now'],
     moment: null,
     Discord: null,
+    shouldDeleteMessage: true,
     dependencies: {
         'moment': 'moment',
         'Discord': 'Discord',


### PR DESCRIPTION
Make the time command delete the message because other users are unlikely to want to view the result, and deleting would prevent clutter.